### PR TITLE
Patch 1

### DIFF
--- a/2022/Day04.pm
+++ b/2022/Day04.pm
@@ -1,10 +1,8 @@
 package Day04;
 
-use 5.30.0;
-use strict;
+use 5.30;
 use warnings;
-use feature "signatures";
-no warnings "experimental::signatures";
+use experimental 'signatures';
 
 use File::Slurp;
 

--- a/2022/Day04.pm
+++ b/2022/Day04.pm
@@ -1,6 +1,6 @@
 package Day04;
 
-use 5.30;
+use v5.30;
 use warnings;
 use experimental 'signatures';
 


### PR DESCRIPTION
`use v5.30` is equivalent to `use v5.30.0` and automatically enables strictures. `use 5.30.0` is incorrect syntax; a v-string needs to lead with a `v`. If you want to use plain numeric arguments it would use the form `use 5.030000` but that is considered less readable syntax and only needed for compatibility with Perls older than 2002’s v5.8.0. See [the `use` function docs](https://perldoc.perl.org/functions/use#use-VERSION) for more.

`use experimental 'signatures'` enables the feature and disables its experimental warnings in one step; [this pragma](https://perldoc.perl.org/experimental) has been [included since Perl v5.20](https://perldoc.perl.org/perl5200delta#New-Modules-and-Pragmata) when signatures were also introduced.